### PR TITLE
fixing gdbus for gnome-shell 3.24

### DIFF
--- a/dim-on-battery@nailfarmer.nailfarmer.com/extension.js
+++ b/dim-on-battery@nailfarmer.nailfarmer.com/extension.js
@@ -36,7 +36,7 @@ const DEFAULT_BRIGHTNESS_BATTERY = 50;
 
 const BRIGHTNESS_THRESHOLD = 3;
 
-const BUS_NAME = 'org.gnome.SettingsDaemon';
+const BUS_NAME = 'org.gnome.SettingsDaemon.Power'; // adding .Power as that seems the bus now
 const OBJECT_PATH = '/org/gnome/SettingsDaemon/Power';
 
 const ScreenIface = '<node>\
@@ -44,7 +44,8 @@ const ScreenIface = '<node>\
     <property type="i" name="Brightness" access="readwrite">\
     </property>\
   </interface>\
-</node>';
+</node>'; 
+
 
 
 let brightnessManager = null;


### PR DESCRIPTION
Have fixed the extension for gnome-shell 3.24 - please merge so the great extension continues to deliver it wonderful value.